### PR TITLE
Fix AVC dac_read_search with new kernel

### DIFF
--- a/ipa_custodia.te
+++ b/ipa_custodia.te
@@ -26,6 +26,7 @@ files_tmp_file(ipa_custodia_tmp_t)
 #
 
 allow ipa_custodia_t self:capability { net_admin dac_read_search };
+dontaudit ipa_custodia_t self:capability dac_override;
 allow ipa_custodia_t self:process execmem;
 allow ipa_custodia_t self:fifo_file rw_fifo_file_perms;
 allow ipa_custodia_t self:unix_stream_socket create_stream_socket_perms;

--- a/ipa_custodia.te
+++ b/ipa_custodia.te
@@ -25,7 +25,7 @@ files_tmp_file(ipa_custodia_tmp_t)
 # ipa_custodia local policy
 #
 
-allow ipa_custodia_t self:capability {net_admin};
+allow ipa_custodia_t self:capability { net_admin dac_read_search };
 allow ipa_custodia_t self:process execmem;
 allow ipa_custodia_t self:fifo_file rw_fifo_file_perms;
 allow ipa_custodia_t self:unix_stream_socket create_stream_socket_perms;

--- a/ipa_custodia.te
+++ b/ipa_custodia.te
@@ -25,8 +25,7 @@ files_tmp_file(ipa_custodia_tmp_t)
 # ipa_custodia local policy
 #
 
-# DAC_OVERRIDE to read Dogtag's key material
-allow ipa_custodia_t self:capability {net_admin dac_override};
+allow ipa_custodia_t self:capability {net_admin};
 allow ipa_custodia_t self:process execmem;
 allow ipa_custodia_t self:fifo_file rw_fifo_file_perms;
 allow ipa_custodia_t self:unix_stream_socket create_stream_socket_perms;


### PR DESCRIPTION
This PR fixes AVC on fedora 27 + remove unnecessary capability.

Tested on: el7.5  and fedora 27

See also: https://danwalsh.livejournal.com/77140.html

@wrabcak, could you review from SELinux POV?